### PR TITLE
Restore entriesPromise logic --> auto-refresh on date change

### DIFF
--- a/src/lib/TroiTimeEntries.svelte
+++ b/src/lib/TroiTimeEntries.svelte
@@ -1,25 +1,25 @@
 <script>
   import { troiApi } from "./troiApiService";
   import NewTroiEntryFormRow from "./NewTroiEntryFormRow.svelte";
-  import { onMount } from "svelte";
 
   export let calculationPositionId;
   export let startDate;
   export let endDate;
 
-  let entries = [];
+  let entriesPromise;
   let editEntryIndex;
 
-  onMount(async () => {
-    entries = await $troiApi.getTimeEntries(
+  $: {
+    cancelEdit();
+    entriesPromise = $troiApi.getTimeEntries(
       calculationPositionId,
       startDate,
       endDate
     );
-  });
+  }
 
   async function refresh() {
-    entries = await $troiApi.getTimeEntries(
+    entriesPromise = await $troiApi.getTimeEntries(
       calculationPositionId,
       startDate,
       endDate
@@ -57,45 +57,49 @@
     </thead>
 
     <tbody>
-      {#each entries as entry, index}
-        {#if editEntryIndex === index}
-          <NewTroiEntryFormRow
-            on:submit={refresh}
-            on:cancelEdit={cancelEdit}
-            {calculationPositionId}
-            {entry}
-            editMode={true}
-            deleteEntryCallback={deleteEntry}
-          />
-        {:else}
-          <tr class="align-top">
-            <td class="py-1 pr-2 min-w-[140px] flex justify-between"
-              ><div>{getWeekday(new Date(entry.date).getDay())}</div>
-              <div>{entry.date}</div></td
-            >
-            <td class="px-2 py-1"
-              >{Math.floor(entry.hours)}:{String(
-                Math.floor((entry.hours - Math.floor(entry.hours)) * 60)
-              ).padStart(2, "0")}</td
-            >
-            <td class="px-2 py-1">{entry.description}</td>
-            <td class="py-1 pl-2 flex">
-              <button
-                on:click={() => editEntry(index)}
-                class="inline-block w-14 text-sm font-medium text-indigo-500 underline hover:text-indigo-700 hover:no-underline"
+      {#await entriesPromise}
+        <p>Loading…</p>
+      {:then entries}
+        {#each entries as entry, index}
+          {#if editEntryIndex === index}
+            <NewTroiEntryFormRow
+              on:submit={refresh}
+              on:cancelEdit={cancelEdit}
+              {calculationPositionId}
+              {entry}
+              editMode={true}
+              deleteEntryCallback={deleteEntry}
+            />
+          {:else}
+            <tr class="align-top">
+              <td class="py-1 pr-2 min-w-[140px] flex justify-between"
+                ><div>{getWeekday(new Date(entry.date).getDay())}</div>
+                <div>{entry.date}</div></td
               >
-                Edit
-              </button>
-              <button
-                on:click={() => deleteEntry(entry.id)}
-                class="inline-block text-sm font-medium text-indigo-500 underline hover:text-indigo-700 hover:no-underline"
+              <td class="px-2 py-1"
+                >{Math.floor(entry.hours)}:{String(
+                  Math.floor((entry.hours - Math.floor(entry.hours)) * 60)
+                ).padStart(2, "0")}</td
               >
-                Delete
-              </button>
-            </td>
-          </tr>
-        {/if}
-      {/each}
+              <td class="px-2 py-1">{entry.description}</td>
+              <td class="py-1 pl-2 flex">
+                <button
+                  on:click={() => editEntry(index)}
+                  class="inline-block w-14 text-sm font-medium text-indigo-500 underline hover:text-indigo-700 hover:no-underline"
+                >
+                  Edit
+                </button>
+                <button
+                  on:click={() => deleteEntry(entry.id)}
+                  class="inline-block text-sm font-medium text-indigo-500 underline hover:text-indigo-700 hover:no-underline"
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          {/if}
+        {/each}
+      {/await}
       {#if editEntryIndex == null}
         <!-- TODO: work with slots for cell styling -->
         <NewTroiEntryFormRow on:submit={refresh} {calculationPositionId} />


### PR DESCRIPTION
Since the diff-view is a bit messy due to the indentation change: in the `<tbody>` section I only added: 

```html
{#await entriesPromise}
  <p>Loading…</p>
{:then entries}

<!-- ... -->

{\await}
```

I basically restored @nfelger's `entriesPromise` logic, compare [here](https://github.com/nfelger/achill/blob/main/src/lib/TroiTimeEntries.svelte#L9-L17). And added editing-cancellation if an auto-refresh due to a date-change happened.